### PR TITLE
fix: Correct table name for etats_des_lieux

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -79,7 +79,7 @@ const Dashboard = () => {
       
       // Récupérer les données complètes de l'état des lieux
       const { data: etatData, error } = await supabase
-        .from('etats_des_lieux')
+        .from('etat_des_lieux')
         .select('*')
         .eq('id', etatId)
         .single();


### PR DESCRIPTION
The table 'etats_des_lieux' was incorrectly named in the `generatePDF` function in `src/components/Dashboard.tsx`. This commit corrects the table name to 'etat_des_lieux' to match the database schema.