### PR TITLE
feat: make employee selector responsive

### DIFF
--- a/src/components/top-header.tsx
+++ b/src/components/top-header.tsx
@@ -73,7 +73,7 @@ export const Header: React.FC = () => {
                         <div className="text-sm font-medium text-gray-900 truncate">
                           {selectedEmploye.prenom} {selectedEmploye.nom}
                         </div>
-                        <div className="text-xs text-gray-500">Employé sélectionné</div>
+                        <div className="text-xs text-gray-500 hidden md:block">Employé sélectionné</div>
                       </div>
                     ) : (
                       <div>


### PR DESCRIPTION
Hides the 'Cliquer pour sélectionner' and 'employé sélectionné' text on small screens to improve responsive design.